### PR TITLE
Fix : naver init script 수정

### DIFF
--- a/.github/workflows/pep8_linting.yml
+++ b/.github/workflows/pep8_linting.yml
@@ -24,7 +24,7 @@ jobs:
         run: pip install flake8
 
       - name: Run flake8
-        run: flake8 . --count --ignore=E231 --show-source --statistics
+        run: flake8 . --count --ignore=E231,E501 --show-source --statistics
 
       - name: Notify Slack
         if: failure() # 작업이 실패할 경우에만 실행

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Flashenbook
 Flashenbook Project
+

--- a/airflow/scripts/get_api_library.py
+++ b/airflow/scripts/get_api_library.py
@@ -1,0 +1,81 @@
+import requests
+import os
+from datetime import datetime
+import pandas as pd
+from dotenv import load_dotenv
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+# JSON 데이터를 가져오는 함수
+def get_json_data(page_no, lib_key):
+    url = "https://www.nl.go.kr/seoji/SearchApi.do?cert_key=" + lib_key
+    option = "&result_style=json&page_size=500&ebook_yn=N&page_no=" + \
+        str(page_no)
+
+    retry = Retry(total=3, backoff_factor=1)  # 최대 3번까지 재시도, 간격은 1초씩 증가
+    adapter = HTTPAdapter(max_retries=retry)  # 재시도를 하기 위한 http 연결 관리
+    http = requests.Session()
+    http.mount("https://", adapter)
+
+    try:
+        response = http.get(url + option)
+        response.raise_for_status()  # 요청이 실패했을 시 connection error 발생
+        return response.json()
+    # connection 오류 발생 시 예외 처리
+    except requests.exceptions.RequestException as e:
+        print(f"Error while fetching data: {e}")
+        return None
+
+
+def extract_isbn(data):
+    if data is None:
+        return []
+
+    isbn = []
+    docs = data.get("docs", [])
+
+    for doc in docs:
+        if doc.get("EA_ISBN"):
+            isbn.append(doc.get("EA_ISBN"))
+
+    return isbn
+
+
+# csv를 저장
+def save_to_csv(isbn_list, filename):
+    df = pd.DataFrame({"ISBN": isbn_list})  # 데이터프레임 생성
+    df.to_csv(filename, index=False)
+
+
+def main(api_key):
+    isbn_list = []
+
+    # limit 호출 횟수를 감안하여 첫 번째 페이지는 따로 탐색해 전체 페이지 확인 후 isbn 작업 처리
+    json_data = get_json_data(1, api_key)
+    total_page = int(json_data["TOTAL_COUNT"]) // 500
+    isbn_list.extend(extract_isbn(json_data))
+
+    # isbn_list 생성 (나머지 페이지에 대해서)
+    # 1119까지 완료
+    for i in range(2, total_page // 5 + 1):
+        data = get_json_data(i, api_key)
+        isbn_list.extend(extract_isbn(data))
+        print(f"success page number: {i}")
+
+    # csv 파일 저장
+    output_path = "airflow/data"
+    today = datetime.now().strftime("%Y-%m-%d")
+    os.makedirs(output_path, exist_ok=True)
+    csv_filename = os.path.join(output_path, f"{today}_init.csv")
+
+    save_to_csv(isbn_list, csv_filename)
+
+    print(f"complete to save {today}_init.csv")
+
+
+if __name__ == "__main__":
+    load_dotenv()  # env 파일 로드
+
+    api_key = os.getenv("LIB_KEY")
+    isbn_list = main(api_key)

--- a/airflow/scripts/get_api_new_isbn.py
+++ b/airflow/scripts/get_api_new_isbn.py
@@ -1,0 +1,81 @@
+import requests
+import os
+from datetime import datetime
+import pandas as pd
+from dotenv import load_dotenv
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+# JSON 데이터를 가져오는 함수
+def get_json_data(page_no, api_key):
+    url = "http://www.aladin.co.kr/ttb/api/ItemList.aspx?ttbkey=" + api_key
+    option = "&QueryType=ItemNewAll&MaxResults=100&SearchTarget=Book&output=JS&Version=20131101&start=" + \
+        str(page_no)
+
+    retry = Retry(total=3, backoff_factor=1)  # 최대 3번까지 재시도, 간격은 1초씩 증가
+    adapter = HTTPAdapter(max_retries=retry)  # 재시도를 하기 위한 http 연결 관리
+    http = requests.Session()
+    http.mount("https://", adapter)
+
+    try:
+        response = http.get(url + option)
+        response.raise_for_status()  # 요청이 실패했을 시 connection error 발생
+        return response.json()
+    # connection 오류 발생 시 예외 처리
+    except requests.exceptions.RequestException as e:
+        print(f"Error while fetching data: {e}")
+        return None
+
+
+def extract_isbn(data):
+    if data is None:
+        return []
+
+    isbn = []
+    items = data.get("item", [])
+
+    for item in items:
+        if item.get("pubDate") == today:
+            isbn.append(item.get("isbn13"))
+
+    return isbn
+
+
+# csv를 저장
+def save_to_csv(isbn_list, filename):
+    df = pd.DataFrame({"ISBN": isbn_list})  # 데이터프레임 생성
+    df.to_csv(filename, index=False)
+
+
+def main(api_key):
+    new_isbn_list = []  # 오늘 날짜의 신간 isbn을 저장할 List
+
+    # limit 호출 횟수를 감안하여 첫 번째 페이지는 따로 탐색해 전체 페이지 확인 후 isbn 작업 처리
+    json_data = get_json_data(1, api_key)
+    total_page = int(json_data["totalResults"]) // int(json_data["itemsPerPage"])
+    new_isbn_list.extend(extract_isbn(json_data))
+
+    for i in range(2, total_page + 1):
+        data = get_json_data(i, api_key)
+        isbn_list.extend(extract_isbn(data))
+        print(f"success page number: {i}")
+
+    # csv 파일 저장
+    output_path = "airflow/data"
+    today = datetime.now().strftime("%Y-%m-%d")
+    os.makedirs(output_path, exist_ok=True)
+    csv_filename = os.path.join(output_path, f"{today}.csv")
+
+    save_to_csv(isbn_list, csv_filename)
+
+    print(f"complete to save {today}.csv")
+
+
+if __name__ == "__main__":
+    load_dotenv()  # env 파일 로드
+    # 추후 airflow 환경의 날짜를 가지고 와 해당 날짜를 조회하도록 수정 예정
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    api_key = os.getenv("TTB_KEY")
+    isbn_list = main(api_key)

--- a/airflow/scripts/init_get_api_naver.py
+++ b/airflow/scripts/init_get_api_naver.py
@@ -1,0 +1,128 @@
+
+import json
+import os
+from datetime import date
+from dotenv import load_dotenv
+import requests
+import time
+from utils.file_operations import upload_files_to_s3
+from utils.api_operations import get_isbn_list
+import csv
+
+load_dotenv()
+BUCKET_NAME = os.environ.get("BUCKET_NAME")
+site = 'naver'
+source_dir = 'data/'
+TODAY = date.today().strftime("%Y-%m-%d")
+TODAY = '2023-08-16'
+
+
+def get_naver_api_key(number) -> dict:
+    keys = {
+        i: {
+            "naver_client_id": os.environ.get(f"NAVER_CLIENT_ID_{i}"),
+            "naver_client_secret": os.environ.get(f"NAVER_CLIENT_SECRET_{i}")
+        }
+        for i in range(1, 21)
+    }
+
+    return keys[number]
+
+
+def get_new_headers(key_num) -> dict:
+    keys = get_naver_api_key(key_num)
+    naver_client_id = keys.get('naver_client_id')
+    naver_client_secret = keys.get('naver_client_secret')
+    headers = {
+        "X-Naver-Client-Id": naver_client_id,
+        "X-Naver-Client-Secret": naver_client_secret
+    }
+    return headers
+
+
+def save_files(isbn_list, books, file_num):
+    file_path = f'{source_dir}isbn/raw+isbn+{TODAY}+init+{file_num}.csv'
+
+    # 디렉터리가 존재하는지 확인하고, 없으면 생성
+    directory = os.path.dirname(file_path)
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+    with open(file_path, 'w', newline='') as file:
+        writer = csv.writer(file)
+        writer.writerow(["ISBN"])
+        for isbn in isbn_list:
+            writer.writerow([isbn])
+
+    file_path = f"{source_dir}{site}/raw+book_info+{site}+{TODAY}+init+books_{file_num}.json"
+    directory = os.path.dirname(file_path)
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(books, f, ensure_ascii=False, indent=4)
+
+
+def fetch_api_data(isbn_list):
+    books = {'items': []}
+    valid_isbn_list = []
+    valid_isbn_cnt = 0
+    key_num = 1
+    file_num = 1
+    url = "https://openapi.naver.com/v1/search/book.json"
+    headers = get_new_headers(key_num)
+
+    for i, isbn in enumerate(isbn_list):
+        params = {
+            "query": isbn,
+            "start": '1'
+        }
+
+        time.sleep(0.1)
+
+        try:
+            response = requests.get(url, headers=headers, params=params)
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            print(f"Error while fetching data: {e}")
+            if e.response.status_code == 429:
+                print('Too Many Requests for url')
+                isbn_list.append(isbn)
+
+                # key 변경
+                key_num += 1
+                headers = get_new_headers(key_num)
+                print(f'API Key {key_num}으로 변경')
+
+                continue
+
+        book_info = response.json()
+        if book_info.get("total") == 0:
+            print(f'naver {i} 번째 {isbn} book info 없음!')
+            continue
+
+        books['items'].append(book_info)
+        valid_isbn_list.append(isbn)
+        valid_isbn_cnt += 1
+
+        print(f'naver {i} 번째 {isbn} book info 수집, 현재 {valid_isbn_cnt}개')
+
+        # 5000개 간격으로 나눠서 파일 저장
+        if valid_isbn_cnt % 5000 == 0:
+            save_files(valid_isbn_list, books, file_num)
+            file_num += 1
+            valid_isbn_list = []
+            books = {'items': []}
+
+    save_files(valid_isbn_list, books, file_num)
+
+
+def main():
+    isbn_object_key = f'raw/isbn/{TODAY}/raw.csv'
+    isbn_list = get_isbn_list(BUCKET_NAME, isbn_object_key)
+    fetch_api_data(isbn_list)
+    upload_files_to_s3(BUCKET_NAME, f'{source_dir}isbn/')
+    upload_files_to_s3(BUCKET_NAME, f'{source_dir}{site}/')
+
+
+if __name__ == "__main__":
+    main()

--- a/airflow/scripts/init_isbn_file_to_s3.py
+++ b/airflow/scripts/init_isbn_file_to_s3.py
@@ -1,0 +1,40 @@
+import os
+from datetime import datetime
+from dotenv import load_dotenv
+import boto3
+
+load_dotenv()  # env 파일 로드
+
+# AWS 계정 및 리전 설정
+aws_access_key_id = os.getenv("AWS_ACCESS_KEY_ID")
+aws_secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+bucket_name = os.getenv("BUCKET_NAME")
+s3_folder_path = 'raw/isbn/'
+# 현재 날짜를 yyyy-mm-dd 형식으로 포맷팅
+today = datetime.now().strftime("%Y-%m-%d")
+
+# S3에 업로드할 파일명
+s3_filename = f"{today}_init.csv"
+
+# 저장할 로컬 CSV 파일 경로
+local_csv_filename = f"airflow/data/{today}_init.csv"
+
+
+# S3 클라이언트 생성
+s3_client = boto3.client(
+    's3',
+    aws_access_key_id=aws_access_key_id,
+    aws_secret_access_key=aws_secret_access_key
+)
+
+# 폴더가 없으면 생성
+folder_prefix = os.path.dirname(s3_folder_path)
+if folder_prefix and not folder_prefix.endswith('/'):
+    folder_prefix += '/'
+s3_client.put_object(Bucket=bucket_name, Key=folder_prefix)
+
+# 로컬 파일을 S3 버킷에 업로드
+s3_client.upload_file(local_csv_filename, bucket_name,
+                      s3_folder_path + os.path.basename(s3_filename))
+
+print(f"{s3_folder_path}{os.path.basename(s3_filename)} 파일이 S3 버킷에 업로드되었습니다.")

--- a/airflow/scripts/isbn_file_to_s3.py
+++ b/airflow/scripts/isbn_file_to_s3.py
@@ -1,0 +1,46 @@
+import os
+from datetime import datetime
+from dotenv import load_dotenv
+import boto3
+
+
+def main(search_date):
+    # S3에 업로드할 파일명
+    s3_filename = f"{search_date}.csv"
+
+    # 저장할 로컬 CSV 파일 경로
+    local_csv_filename = f"airflow/data/{search_date}.csv"
+
+    # S3 클라이언트 생성
+    s3_client = boto3.client(
+        's3',
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key
+    )
+
+    # 폴더가 없으면 생성
+    folder_prefix = os.path.dirname(s3_folder_path)
+    if folder_prefix and not folder_prefix.endswith('/'):
+        folder_prefix += '/'
+    s3_client.put_object(Bucket=bucket_name, Key=folder_prefix)
+
+    # 로컬 파일을 S3 버킷에 업로드
+    s3_client.upload_file(local_csv_filename, bucket_name,
+                          s3_folder_path + os.path.basename(s3_filename))
+
+    print(f"{s3_folder_path}{os.path.basename(s3_filename)} 파일이 S3 버킷에 업로드되었습니다.")
+
+
+if __name__ == "__main__":
+    load_dotenv()  # env 파일 로드
+    # 추후 airflow 환경의 날짜를 가지고 와 해당 날짜를 조회하도록 수정 예정
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    # AWS 계정 및 리전 설정
+    aws_access_key_id = os.getenv("AWS_ACCESS_KEY_ID")
+    aws_secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+    bucket_name = os.getenv("BUCKET_NAME")
+    s3_folder_path = 'raw/isbn/'
+    # 현재 날짜를 yyyy-mm-dd 형식으로 포맷팅
+
+    main(today)


### PR DESCRIPTION
## Description
- 국립중앙도서관 API를 통해 수집한 isbn 데이터를 Naver api로 걸러 유효한 isbn 리스트를 추출하고, s3에 5000개 단위로 끊어서 파일 생성하도록 수정
-  raw/isbn/날짜/init/번호.csv 형식으로 저장
- 코드 리팩토링

## 이 PR의 유형은 무엇인가요? (해당되는 모든 항목을 체크하세요)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## 관련 이슈 및 문서
Fixes #34, #36
Related to #44, #45
<!--
이 형식으로 이슈 번호를 링크해주세요: Fixes #123
-->

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## 테스트를 추가하셨나요?

- [ ] 👍 네
- [x] 🙅 아니요, 필요하지 않습니다
- [ ] 🙋 아니요, 도움이 필요합니다

## 문서에 추가하셨나요?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed
