### PR TITLE
Feat : cleaned to curated 변환 lambda function 추가

### DIFF
--- a/lambda/cleaned_to_curated/lambda_function.py
+++ b/lambda/cleaned_to_curated/lambda_function.py
@@ -1,0 +1,117 @@
+import boto3
+import re
+import pandas as pd
+from io import BytesIO
+
+s3 = boto3.client('s3')
+
+
+def lambda_handler(event, context):
+    try:
+        bucket = event['Records'][0]['s3']['bucket']['name']
+        cleaned_key = event['Records'][0]['s3']['object']['key']
+
+        if re.match(r'cleaned/book_info/.*/\d{4}-\d{2}-\d{2}/.*.parquet', cleaned_key):
+            date = cleaned_key.split('/')[3]
+            book_type = cleaned_key.split('/')[4].replace(".parquet", "")
+            keys = [
+                f'cleaned/book_info/naver/{date}/{book_type}.parquet',
+                f'cleaned/book_info/kakao/{date}/{book_type}.parquet',
+                f'cleaned/book_info/aladin/{date}/{book_type}.parquet',
+            ]
+            book_info_key = f'curated/book_info/{date}/book_info.parquet'
+            book_detail_key = f'curated/book_detail/{date}/book_detail.parquet'
+
+            # S3에서 parquet 파일 읽기
+            def read_parquet_from_s3(bucket, key):
+                try:
+                    response = s3.get_object(Bucket=bucket, Key=key)
+                    data = response['Body'].read()
+                    return pd.read_parquet(BytesIO(data))
+                except s3.exceptions.NoSuchKey:
+                    return None
+
+            dfs = [read_parquet_from_s3(bucket, key) for key in keys]
+
+            # 모든 파일이 존재하는지 확인
+            if any(df is None or df.empty for df in dfs):
+                return {
+                    'statusCode': 400,
+                    'body': 'One or more files do not exist!'
+                }
+
+            # df 정의
+            df_naver = dfs[0]
+            df_kakao = dfs[1]
+            df_aladin = dfs[2]
+
+            # 1. book_info 생성
+            # 데이터 프레임에서 필요한 정보 선택
+            df_naver_selected = df_naver[['ISBN', 'IMAGE_URL']]
+            df_kakao_selected = df_kakao[['ISBN', 'AUTHOR', 'TRANSLATOR']]
+            df_aladin_selected = df_aladin[[
+                'ISBN', 'TITLE', 'CATEGORY_ID', 'PUBLISHER', 'PUBDATE', 'PRICE', 'PAGE_CNT']]
+
+            # 선택된 열들로 새로운 데이터프레임 생성
+            df_selected = pd.merge(pd.merge(
+                df_naver_selected, df_kakao_selected, on='ISBN'), df_aladin_selected, on='ISBN')
+
+            # parquet 파일로 변환
+            parquet_buffer = BytesIO()
+            df_selected.to_parquet(parquet_buffer)
+
+            # 변환된 데이터를 S3에 저장
+            s3.put_object(Bucket=bucket, Key=book_info_key,
+                          Body=parquet_buffer.getvalue())
+
+            # 2. book_detail 생성
+            header = ['ISBN', 'WEB_CODE', 'SALE_URL',
+                      'SALE_PRICE', 'SALE_STATUS', 'DESCRIPTION', 'RANK']
+
+            # 주어진 헤더의 각 열에 대해, 해당 열이 데이터 프레임에 존재하는지 확인하고,
+            # 존재하지 않으면 NaN 값을 포함하는 열을 추가하고, WEB_CODE 열의 값을 설정
+            def select_columns(df, header, web_code=None):
+                for col in header:
+                    if col not in df.columns:
+                        df[col] = None
+                if web_code:
+                    df['WEB_CODE'] = web_code
+                if 'SALE_PRICE' in df.columns and df['SALE_PRICE'].dtype == 'object':
+                    df['SALE_PRICE'] = df['SALE_PRICE'].str.replace(
+                        ',', '').astype(int)
+                return df[header]
+
+            # 각 데이터 프레임에서 주어진 헤더의 열만 선택
+            df_naver_selected = select_columns(df_naver, header, web_code='NA')
+            df_kakao_selected = select_columns(df_kakao, header, web_code='KK')
+            df_aladin_selected = select_columns(
+                df_aladin, header, web_code='AL')
+
+            # 선택된 열들로 새로운 데이터프레임 생성
+            df_selected = pd.concat(
+                [df_naver_selected, df_kakao_selected, df_aladin_selected])
+
+            # parquet 파일로 변환
+            parquet_buffer = BytesIO()
+            df_selected.to_parquet(parquet_buffer)
+
+            # 변환된 데이터를 S3에 저장
+            s3.put_object(Bucket=bucket, Key=book_detail_key,
+                          Body=parquet_buffer.getvalue())
+
+            return {
+                'statusCode': 200,
+                'body': 'Parquet file created successfully!'
+            }
+        else:
+            print(
+                f"Object key {cleaned_key} does not match the expected pattern.")
+            return {
+                'statusCode': 500,
+                'body': f"Object doesn't match the expected pattern: {cleaned_key}"
+            }
+    except Exception as e:
+        return {
+            'statusCode': 500,
+            'body': f'Failure: {str(e)}'
+        }


### PR DESCRIPTION
## Description
- cleaned to curated 변환 lambda function `de-4-1_cleaned_to_curated` 추가
- 각 도서사이트의 도서데이터 병합하여 book_info, book_detail 데이터를 parquet 파일 형식으로 생성
- raw, cleaned 에 적재하지 않고 바로 curated로 넘김
- book_info 경로 : `curated/book_info/{date}/book_info.parquet`
- book_detail 경로 :  `curated/book_detail/{date}/book_detail.parquet`
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## 이 PR의 유형은 무엇인가요? (해당되는 모든 항목을 체크하세요)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## 관련 이슈 및 문서
Close #80 
<!--
이 형식으로 이슈 번호를 링크해주세요: Fixes #123
-->

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## 테스트를 추가하셨나요?
<img width="795" alt="image" src="https://github.com/FlaschenbookProject/Flaschenbook/assets/103317018/99d03545-4ed6-4b37-9ce5-0b8be26ebe1a">

AWS Lambda `de-4-1_cleaned_to_curated` 에 추가했습니다.
- [x] 👍 네
- [ ] 🙅 아니요, 필요하지 않습니다
- [ ] 🙋 아니요, 도움이 필요합니다

## 문서에 추가하셨나요?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed
