### PR TITLE
Fix : 배치 데이터 파이프라인 오류 수정

### DIFF
--- a/airflow/scripts/get_api.py
+++ b/airflow/scripts/get_api.py
@@ -18,7 +18,6 @@ def main():
     load_dotenv()
 
     BUCKET_NAME = os.environ.get("BUCKET_NAME")
-    BOOK_SITE = os.environ.get("BOOK_SITE")
 
     # TODAY를 환경 변수가 아닌 시스템 변수로 수정
     if len(sys.argv) < 2:
@@ -26,6 +25,8 @@ def main():
 
     print(sys.argv)
     TODAY = sys.argv[1]
+    BOOK_SITE = sys.argv[2]
+    print(BOOK_SITE)
 
     isbn_object_key = f"raw/isbn/{TODAY}/new.csv"
     source_dir = f"data/{BOOK_SITE}/"

--- a/airflow/scripts/get_api_new_isbn.py
+++ b/airflow/scripts/get_api_new_isbn.py
@@ -57,7 +57,6 @@ def main():
     if len(sys.argv) < 2:
         sys.exit(1)
 
-    print(sys.argv)
     today = sys.argv[1]
     print(f"{today} New Book")
 

--- a/airflow/scripts/utils/api_operations.py
+++ b/airflow/scripts/utils/api_operations.py
@@ -182,13 +182,21 @@ def fetch_api_data(isbn_list: List[str], site: str) -> Dict[str, Dict]:
             print(f"Error while fetching data: {e}")
 
         book_info = response.json()
-        if site == 'naver' and book_info['total'] == 0:
+
+        # book_info가 None인 경우 모든 웹사이트에 대해 확인할 필요 없음
+        if book_info is None:
             print(f'{site} {i} 번째 {isbn} book info 없음!')
             continue
-        elif site == 'kakao' and book_info['meta']['total_count'] == 0:
+
+        # key가 없는 경우를 대비해 get으로 수정
+        if site == 'naver' and book_info.get('total') == 0:
             print(f'{site} {i} 번째 {isbn} book info 없음!')
             continue
-        elif site == 'aladin' and book_info['errorCode'] == 8:
+        elif site == 'kakao':
+            if book_info.get('meta') is None or book_info.get('meta').get('total_count') == 0:
+                print(f'{site} {i} 번째 {isbn} book info 없음!')
+                continue
+        elif site == 'aladin' and book_info.get('errorCode') == 8:
             print(f'{site} {i} 번째 {isbn} book info 없음!')
             continue
 


### PR DESCRIPTION
## Description
- daily_fetch_new_book 호출 시 환경 변수인 site 모두 동일한 naver로 넘어가는 오류 system 파라미터로 로직 바꾸어 수정
- Jinja 템플릿을 통해 execution date 조회하도록 반영
- S3KeySensor 사용 시 object_key가 잘못 넘어가 발생한 오류 수정
- kakao의 경우 request 값이 None인 경우 존재 모든 사이트에 대해서 request 값이 None인 경우 조회되지 않는 데이터로 예외 처리 
- fetch_api_data 함수에서 존재하지 않는 key의 경우 keyError가 발생하지 않도록 dict['key']가 아닌 dict.get('key')로 수정

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## 이 PR의 유형은 무엇인가요? (해당되는 모든 항목을 체크하세요)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## 관련 이슈 및 문서
Fixes #65
<!--
이 형식으로 이슈 번호를 링크해주세요: Fixes #123
-->

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## 테스트를 추가하셨나요?

- [ ] 👍 네
- [x] 🙅 아니요, 필요하지 않습니다
- [ ] 🙋 아니요, 도움이 필요합니다

## 문서에 추가하셨나요?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed
