### PR TITLE
fix: 교보 책 속으로 오류 수정

### DIFF
--- a/airflow/scripts/scrap_kyobo.py
+++ b/airflow/scripts/scrap_kyobo.py
@@ -47,12 +47,12 @@ def scrap_review_and_content(isbn_list):
                 print(f"Error encountered: {e}")
                 continue
 
-            book_content_xpath = '//*[@id="scrollSpyProdInfo"]/div[10]/div[2]/div[1]/div/p'
+            book_content = ""
             try:
                 print(f"{isbn} 책 속으로 조회 시작")
-                book_content_element = page.locator(book_content_xpath)
-                if book_content_element:
-                    book_content = book_content_element.inner_text()
+                if page.locator('.product_detail_area.book_inside').count() > 0:
+                    # 책 속으로가 존재하는 경우에만 텍스트를 추출하고 출력
+                    book_content = page.locator('.product_detail_area.book_inside .auto_overflow_inner .info_text').inner_text()
                     book_content = book_content.replace('<br>', '\n')
                 else:
                     print(f"'{isbn}'의 책 속으로가 없습니다.")
@@ -60,12 +60,13 @@ def scrap_review_and_content(isbn_list):
                 print(f"Error encountered: {e}")
                 continue
 
-            if book_content:
+            if len(book_content) != 0:
                 content_list = book_content.split('\n')
                 for content in content_list:
                     if content:
                         content_dict = {'isbn': isbn, 'content': content}
                         contents.append(content_dict)
+                        print(f"{isbn} 내용: {content}")
 
             try:
                 review_cnt_text_xpath = '//*[@id="contents"]/div[2]/div[1]/div/div[1]/ul/li[3]/a/span/span'


### PR DESCRIPTION
## Description
- 교보 책 속으로 xpath가 모두 달라 class명으로 구분할 수 있게 로직 수정 

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## 이 PR의 유형은 무엇인가요? (해당되는 모든 항목을 체크하세요)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## 관련 이슈 및 문서
Fixes #91 
<!--
이 형식으로 이슈 번호를 링크해주세요: Fixes #123
-->

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## 테스트를 추가하셨나요?

- [ ] 👍 네
- [x] 🙅 아니요, 필요하지 않습니다
- [ ] 🙋 아니요, 도움이 필요합니다

## 문서에 추가하셨나요?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed
