### PR TITLE
fix : 화면 로드 전 요소 조회해 요소를 찾지 못하는 오류 수정

### DIFF
--- a/airflow/scripts/scrap_kyobo.py
+++ b/airflow/scripts/scrap_kyobo.py
@@ -47,6 +47,8 @@ def scrap_review_and_content(isbn_list):
                 print(f"Error encountered: {e}")
                 continue
 
+            page.wait_for_load_state('domcontentloaded')
+
             book_content = ""
             try:
                 print(f"{isbn} 책 속으로 조회 시작")


### PR DESCRIPTION
## Description
- 책 속으로 스크래핑 시 요소가 로드되기 전 조회해 찾지 못하는 오류 수정 

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## 이 PR의 유형은 무엇인가요? (해당되는 모든 항목을 체크하세요)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## 관련 이슈 및 문서

<!--
이 형식으로 이슈 번호를 링크해주세요: Fixes #123
-->

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## 테스트를 추가하셨나요?

- [ ] 👍 네
- [x] 🙅 아니요, 필요하지 않습니다
- [ ] 🙋 아니요, 도움이 필요합니다

## 문서에 추가하셨나요?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed
