### PR TITLE
Fix : survey API 버그 수정

### DIFF
--- a/flaschenbook-spring-app/flaschenbook/src/main/java/com/book/flaschenbook/entity/SurveyContentEntity.java
+++ b/flaschenbook-spring-app/flaschenbook/src/main/java/com/book/flaschenbook/entity/SurveyContentEntity.java
@@ -1,19 +1,43 @@
 package com.book.flaschenbook.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Data;
 import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.Subselect;
+import org.hibernate.annotations.Synchronize;
+
+import java.io.Serializable;
+import java.util.Objects;
 
 @Data
 @Entity
-@Immutable
+@IdClass(SurveyContentId.class)
 @Table(name = "SurveyContent")
 public class SurveyContentEntity {
-
     @Id
     private String id;
-    private String content;
+
+    @Id
     private String type;
+
+    private String content;
+}
+
+@Data
+class SurveyContentId implements Serializable {
+    private String id;
+    private String type;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SurveyContentId that = (SurveyContentId) o;
+        return Objects.equals(id, that.id) && Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, type);
+    }
 }

--- a/flaschenbook-spring-app/flaschenbook/src/main/java/com/book/flaschenbook/repository/SurveyContentRepository.java
+++ b/flaschenbook-spring-app/flaschenbook/src/main/java/com/book/flaschenbook/repository/SurveyContentRepository.java
@@ -2,11 +2,14 @@ package com.book.flaschenbook.repository;
 
 import com.book.flaschenbook.entity.SurveyContentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface SurveyContentRepository extends JpaRepository<SurveyContentEntity, Long> {
-    List<SurveyContentEntity> findAllByType(String type);
+    List<SurveyContentEntity> findByType(String type);
+
 }

--- a/flaschenbook-spring-app/flaschenbook/src/main/java/com/book/flaschenbook/service/SurveyServiceImpl.java
+++ b/flaschenbook-spring-app/flaschenbook/src/main/java/com/book/flaschenbook/service/SurveyServiceImpl.java
@@ -45,7 +45,7 @@ public class SurveyServiceImpl implements SurveyService{
     }
 
     private List<SurveyContentEntity> getRandomContentsByType(String type, int count) {
-        List<SurveyContentEntity> contentsByType = surveyContentRepository.findAllByType(type);
+        List<SurveyContentEntity> contentsByType = surveyContentRepository.findByType(type);
         Collections.shuffle(contentsByType);
         return contentsByType.subList(0, Math.min(contentsByType.size(), count));
     }
@@ -75,6 +75,7 @@ public class SurveyServiceImpl implements SurveyService{
         // Create and save SurveyDetailsEntities
         for (SurveyContentModel contentModel : selectedContentsDTO.getSelectedContents()) {
             SurveyDetailsEntity detailsEntity = new SurveyDetailsEntity();
+            detailsEntity.setSurveyId(surveysEntity.getSurveyId());
             detailsEntity.setSurvey(surveysEntity);
             detailsEntity.setContentType(contentModel.getType());
             detailsEntity.setContentId(contentModel.getId());


### PR DESCRIPTION
## Description
- Survey content 타입 'C' 못가져오는 버그 수정
  -> Entity의 경우 레코드를 식별할 수 있는 Id가 필수적인데, SurveyContentEntity는 View table이라서 id가 중복되었음.
       그래서 같은 Id를 가지는 경우 하나의 값만 가져와서 데이터를 정확하게 가져오지 못함. 
  해결 : 복합키를 생성함
- surveyId Detail테이블에 저장 안되는 버그 수정

## 이 PR의 유형은 무엇인가요? (해당되는 모든 항목을 체크하세요)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## 관련 이슈 및 문서

<!--
이 형식으로 이슈 번호를 링크해주세요: Fixes #123
-->

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## 테스트를 추가하셨나요?

- [ ] 👍 네
- [ ] 🙅 아니요, 필요하지 않습니다
- [ ] 🙋 아니요, 도움이 필요합니다

## 문서에 추가하셨나요?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed
