### PR TITLE
Feat : CI/CD를 위한 CodePipeline, CodeBuild 자원 생성 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # react-dockerizing/Dockerfile
 
 # base image 설정(as build 로 완료된 파일을 밑에서 사용할 수 있다.)
-FROM node:14-alpine as frontend-build
+FROM 304451662531.dkr.ecr.ap-northeast-2.amazonaws.com/node-14-alpine:latest as frontend-build
 
 # 컨테이너 내부 작업 디렉토리 설정
 WORKDIR /app

--- a/flaschenbook-spring-app/terraform/code_role.tf
+++ b/flaschenbook-spring-app/terraform/code_role.tf
@@ -1,0 +1,149 @@
+# IAM Role for CodeBuild
+resource "aws_iam_role" "flb-codebuild_role" {
+  name = "flb-codebuild-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "codebuild.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+resource "aws_iam_policy" "ecr_policy" {
+  name        = "ecr_policy"
+  description = "Policy to allow CodeBuild to access ECR"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:GetAuthorizationToken",
+          "ecr:CreateRepository"
+        ],
+        Effect   = "Allow",
+        Resource = "*"
+      }
+    ]
+  })
+}
+resource "aws_iam_role_policy_attachment" "codebuild_cloudwatch_policy_attachment" {
+  role       = aws_iam_role.flb-codebuild_role.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
+}
+resource "aws_iam_role_policy_attachment" "codebuild_s3_policy_attachment" {
+  role       = aws_iam_role.flb-codebuild_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+resource "aws_iam_role_policy_attachment" "codebuild_ecr_policy_attachment" {
+  policy_arn = aws_iam_policy.ecr_policy.arn
+  role       = aws_iam_role.flb-codebuild_role.name
+}
+
+
+resource "aws_iam_policy" "codestar_connections_policy" {
+  name        = "codestar-connections-policy"
+  description = "Policy to allow usage of CodeStar Connection"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow",
+        Action   = "codestar-connections:UseConnection",
+        Resource = "${aws_codestarconnections_connection.flb-github-connection.arn}"
+      }
+    ]
+  })
+}
+resource "aws_iam_policy" "codebuild_startbuild_policy" {
+  name        = "codebuild-startbuild-policy"
+  description = "Policy to allow starting CodeBuild projects"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow",
+        Action   = "codebuild:StartBuild",
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+
+resource "aws_iam_role" "flb-codepipeline_role" {
+  name = "flb-codepipeline-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "codepipeline.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+resource "aws_iam_role_policy_attachment" "codepipeline_policy_attachment" {
+  role       = aws_iam_role.flb-codepipeline_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodePipeline_FullAccess"
+}
+resource "aws_iam_role_policy_attachment" "s3_policy_attachment" {
+  role       = aws_iam_role.flb-codepipeline_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+resource "aws_iam_role_policy_attachment" "codestar_connections_policy_attachment" {
+  role       = aws_iam_role.flb-codepipeline_role.name
+  policy_arn = aws_iam_policy.codestar_connections_policy.arn
+}
+resource "aws_iam_role_policy_attachment" "codebuild_policy_attachment" {
+  role       = aws_iam_role.flb-codepipeline_role.name
+  policy_arn = aws_iam_policy.codebuild_startbuild_policy.arn
+}
+resource "aws_iam_role_policy_attachment" "cloudwatch_policy_attachment" {
+  role       = aws_iam_role.flb-codepipeline_role.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
+}
+
+resource "aws_iam_role" "flb-codedeploy_role" {
+  name = "flb-codedeploy_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "codedeploy.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+resource "aws_iam_role_policy_attachment" "codedeploy_policy_attachment1" {
+  role       = aws_iam_role.flb-codedeploy_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployFullAccess"
+}
+resource "aws_iam_role_policy_attachment" "codedeploy_policy_attachment2" {
+  role       = aws_iam_role.flb-codedeploy_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS"
+}

--- a/flaschenbook-spring-app/terraform/codebuild.tf
+++ b/flaschenbook-spring-app/terraform/codebuild.tf
@@ -1,0 +1,58 @@
+locals {
+  ecr_base_url = trimsuffix(aws_ecr_repository.flaschenbook-frontend.repository_url, "/flaschenbook-frontend")
+}
+
+resource "aws_codebuild_project" "flb-frontend-codebuild" {
+  name          = "flb-frontend-codebuild"
+  build_timeout = "5"
+  service_role  = aws_iam_role.flb-codebuild_role.arn
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type    = "BUILD_GENERAL1_SMALL"
+    image           = "aws/codebuild/standard:5.0"
+    type            = "LINUX_CONTAINER"
+    privileged_mode = true
+    environment_variable {
+      name  = "REPOSITORY_NAME"
+      value = aws_ecr_repository.flaschenbook-frontend.name
+    }
+    environment_variable {
+      name  = "ECR_BASE_URL"
+      value = local.ecr_base_url
+    }
+    environment_variable {
+      name  = "REPOSITORY_URI"
+      value = aws_ecr_repository.flaschenbook-frontend.repository_url
+    }
+    environment_variable {
+      name  = "CONTAINER_NAME"
+      value = "flb-frontend"
+    }
+  }
+
+  source {
+    type      = "CODEPIPELINE"
+    buildspec = <<-EOT
+      version: 0.2
+      phases:
+        pre_build:
+          commands:
+            - echo "Logging in to Amazon ECR..."
+            - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_BASE_URL
+        build:
+          commands:
+            - echo "Building the Docker image..."
+            - docker build -t $REPOSITORY_NAME .
+            - docker tag $REPOSITORY_NAME:latest $REPOSITORY_URI:latest
+        post_build:
+          commands:
+            - echo "Pushing the Docker image..."
+            - docker push $REPOSITORY_URI:latest
+            - echo '[{"name":"$CONTAINER_NAME","imageUri":"'$REPOSITORY_URI:latest'"}]' > imagedefinitions.json
+            - mv imagedefinitions.json /codebuild/output/
+    EOT
+  }
+}

--- a/flaschenbook-spring-app/terraform/codepipeline.tf
+++ b/flaschenbook-spring-app/terraform/codepipeline.tf
@@ -1,0 +1,65 @@
+resource "aws_codepipeline" "flb-frontend-pipeline" {
+  name     = "flb-frontend-pipeline"
+  role_arn = aws_iam_role.flb-codepipeline_role.arn
+
+  artifact_store {
+    type     = "S3"
+    location = var.bucket_name
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "SourceAction"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["source_output"]
+
+      configuration = {
+        ConnectionArn    = "${aws_codestarconnections_connection.flb-github-connection.arn}"
+        FullRepositoryId = "FlaschenbookProject/Flaschenbook"
+        BranchName       = "main"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name             = "BuildAction"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["source_output"]
+      output_artifacts = ["build_output"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = "${aws_codebuild_project.flb-frontend-codebuild.name}"
+      }
+    }
+  }
+
+  # stage {
+  #   name = "Deploy"
+
+  #   action {
+  #     name            = "DeployAction"
+  #     category        = "Deploy"
+  #     owner           = "AWS"
+  #     provider        = "CodeDeployToECS"
+  #     input_artifacts = ["build_output"]
+  #     version         = "1"
+
+  #     configuration = {
+  #       ApplicationName     = "${aws_codedeploy_app.flb-frontend-codedeploy.name}"
+  #       DeploymentGroupName = "${aws_codedeploy_deployment_group.flb-frontend-dg.deployment_group_name}"
+  #       FileName            = "imagedefinitions.json"
+  #     }
+  #   }
+  # }
+}

--- a/flaschenbook-spring-app/terraform/codestarconnection.tf
+++ b/flaschenbook-spring-app/terraform/codestarconnection.tf
@@ -1,0 +1,4 @@
+resource "aws_codestarconnections_connection" "flb-github-connection" {
+  provider_type = "GitHub"
+  name          = "flb-github-connection"
+}

--- a/flaschenbook-spring-app/terraform/ecr.tf
+++ b/flaschenbook-spring-app/terraform/ecr.tf
@@ -11,3 +11,11 @@ resource "aws_ecr_repository" "flaschenbook-backend" {
     scan_on_push = true
   }
 }
+
+resource "aws_ecr_repository" "node_14_alpine" {
+  name                 = "node-14-alpine"
+  image_tag_mutability = "MUTABLE"
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -12,7 +12,7 @@ server {
         try_files $uri $uri/ /index.html;
     }
     location /api/ {
-        proxy_pass http://flaschenbook-dev-ecs-backend-alb-458075013.ap-southeast-1.elb.amazonaws.com/; # Spring Boot 애플리케이션의 포트
+        proxy_pass http://ecs-flb-backend-alb-1415357375.ap-northeast-2.elb.amazonaws.com/; # Spring Boot 애플리케이션의 포트
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }


### PR DESCRIPTION
## Description
- CI/CD를 위한 Frontend CodePipeline, CodeBuild 자원 생성  (Backend는 아직입니다)
- Github 연결 추가
- nginx 프록시 주소 인프라 새로 구축하면서 생성된 주소로 변경
- 아래 에러 해결을 위해 codebuild를 위한 전용 이미지 ECR에 생성
```
Step 1/12 : FROM node:14-alpine as frontend-build
toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```
- frontend Dockerfile의 react build하는 기본 이미지 ECR에 생성한 전용이미지로 변경

## 이 PR의 유형은 무엇인가요? (해당되는 모든 항목을 체크하세요)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## 관련 이슈 및 문서
Related to  #148 
<!--
이 형식으로 이슈 번호를 링크해주세요: Fixes #123
-->

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## 테스트를 추가하셨나요?
코드를 main 브랜치에 push 한 후에 테스트 가능할 것 같습니다.

- [ ] 👍 네
- [ ] 🙅 아니요, 필요하지 않습니다
- [x] 🙋 아니요, 도움이 필요합니다

## 문서에 추가하셨나요?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed
